### PR TITLE
feat(config): Endpoints to manage Contact/Feedbacks

### DIFF
--- a/src/main/java/com/openstage/ticketbook/TicketbookApplication.java
+++ b/src/main/java/com/openstage/ticketbook/TicketbookApplication.java
@@ -1,9 +1,12 @@
 package com.openstage.ticketbook;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Ticketbook API", version = "1.0", description = "API for Ticketbook application"))
 public class TicketbookApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/openstage/ticketbook/config/SecurityConfig.java
+++ b/src/main/java/com/openstage/ticketbook/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.openstage.ticketbook.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     // 1. The Hashing Tool (Bean)
@@ -21,18 +23,12 @@ public class SecurityConfig {
     // 2. The Security Rules
     // We disable the default login screen so your HTML frontend works.
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers(
-//                                "/api/auth/**",
-//                                "/v3/api-docs/**",
-//                                "/swagger-ui/**",
-//                                "/swagger-ui.html"
-//                        ).permitAll()
                         .anyRequest().permitAll()
                 );
 

--- a/src/main/java/com/openstage/ticketbook/controller/ContactController.java
+++ b/src/main/java/com/openstage/ticketbook/controller/ContactController.java
@@ -1,0 +1,68 @@
+package com.openstage.ticketbook.controller;
+
+import com.openstage.ticketbook.dto.ContactDTO;
+import com.openstage.ticketbook.model.Contact;
+import com.openstage.ticketbook.service.AuthService;
+import com.openstage.ticketbook.service.ContactService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/contact")
+@RequiredArgsConstructor
+@Tag(name = "Contact", description = "Contact management APIs")
+public class ContactController {
+    private final ContactService contactService;
+    private final AuthService authService;
+
+    @Operation(summary = "Create a new contact", description = "Create a new contact with the given details. Requires authentication.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Contact created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @PostMapping
+    public ResponseEntity<?> createContact(@RequestBody ContactDTO contactDTO, HttpServletRequest request) {
+        if (!authService.isUserAlreadyLoggedIn(request)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not logged in");
+        }
+        return ResponseEntity.ok(contactService.createContact(contactDTO));
+    }
+
+    @Operation(summary = "Get all contacts", description = "Get a list of all contacts. Requires ADMIN role.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @GetMapping
+    public ResponseEntity<?> getAllContacts(HttpServletRequest request) {
+        if (!authService.hasRole(request, "ROLE_ADMIN")) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Access denied");
+        }
+        return ResponseEntity.ok(contactService.getAllContacts());
+    }
+
+    @Operation(summary = "Delete a contact", description = "Delete a contact by its ID. Requires ADMIN role.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Contact deleted successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Contact not found")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteContact(@PathVariable Long id, HttpServletRequest request) {
+        if (!authService.hasRole(request, "ROLE_ADMIN")) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Access denied");
+        }
+        contactService.deleteContact(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/openstage/ticketbook/controller/UserController.java
+++ b/src/main/java/com/openstage/ticketbook/controller/UserController.java
@@ -3,9 +3,11 @@ package com.openstage.ticketbook.controller;
 import com.openstage.ticketbook.dto.ResponseDTO;
 import com.openstage.ticketbook.dto.UserRequestDTO;
 import com.openstage.ticketbook.dto.UserResponseDTO;
-import com.openstage.ticketbook.model.User;
 import com.openstage.ticketbook.service.AuthService;
 import com.openstage.ticketbook.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;
@@ -24,7 +26,11 @@ public class UserController {
     private final AuthService authService;
     private final UserService userService;
 
-    // Get All Users
+    @Operation(summary = "Get all users", description = "Get a list of all users. Requires ADMIN role.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
     @GetMapping
     public ResponseEntity<ResponseDTO<List<UserResponseDTO>>> getAllUsers(HttpServletRequest request) {
         if (!authService.hasRole(request, "ROLE_ADMIN")) {
@@ -33,7 +39,12 @@ public class UserController {
         return ResponseEntity.ok(new ResponseDTO<>(true, "Users retrieved successfully", userService.getAllUsers()));
     }
 
-    // Get User by ID
+    @Operation(summary = "Get user by ID", description = "Get a user by their ID. Requires ADMIN role.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User found"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     @GetMapping("/{id}")
     public ResponseEntity<ResponseDTO<UserResponseDTO>> getUserById(@PathVariable Long id, HttpServletRequest request) {
         if (!authService.hasRole(request, "ROLE_ADMIN")) {
@@ -44,7 +55,12 @@ public class UserController {
                 .orElse(ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseDTO<>(false, "User not found", null)));
     }
 
-    // Update User by ID
+    @Operation(summary = "Update user by ID", description = "Update a user by their ID. Requires ADMIN role or for the user to be updating their own profile.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User updated successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     @PutMapping("/{id}")
     public ResponseEntity<ResponseDTO<UserResponseDTO>> updateUser(@PathVariable Long id, @RequestBody UserRequestDTO userRequestDTO, HttpServletRequest request) {
         if (!authService.hasRole(request, "ROLE_ADMIN") && !authService.isSameUser(request, id)) {
@@ -55,7 +71,12 @@ public class UserController {
                 .orElse(ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseDTO<>(false, "User not found", null)));
     }
 
-    // Delete User by ID
+    @Operation(summary = "Delete user by ID", description = "Delete a user by their ID. Requires ADMIN role or for the user to be deleting their own profile.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User deleted successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<ResponseDTO<Void>> deleteUser(@PathVariable Long id, HttpServletRequest request) {
         if (!authService.hasRole(request, "ROLE_ADMIN") && !authService.isSameUser(request, id)) {
@@ -67,7 +88,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ResponseDTO<>(false, "User not found", null));
     }
 
-    // Test Endpoint
+    @Operation(summary = "Get user profile", description = "A test endpoint to get the user's profile. Requires USER role.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User profile accessed successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
     @GetMapping("/profile")
     public ResponseEntity<@NonNull ResponseDTO<String>> getUserProfile(HttpServletRequest request) {
         // Check role from session

--- a/src/main/java/com/openstage/ticketbook/dto/ContactDTO.java
+++ b/src/main/java/com/openstage/ticketbook/dto/ContactDTO.java
@@ -1,0 +1,14 @@
+package com.openstage.ticketbook.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ContactDTO {
+    private String message;
+}

--- a/src/main/java/com/openstage/ticketbook/model/Contact.java
+++ b/src/main/java/com/openstage/ticketbook/model/Contact.java
@@ -1,0 +1,26 @@
+package com.openstage.ticketbook.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Contact {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String email;
+    private String name;
+    private String message;
+    @CreationTimestamp
+    private Timestamp createdAt;
+}

--- a/src/main/java/com/openstage/ticketbook/repo/ContactRepo.java
+++ b/src/main/java/com/openstage/ticketbook/repo/ContactRepo.java
@@ -1,0 +1,7 @@
+package com.openstage.ticketbook.repo;
+
+import com.openstage.ticketbook.model.Contact;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContactRepo extends JpaRepository<Contact, Long> {
+}

--- a/src/main/java/com/openstage/ticketbook/service/ContactService.java
+++ b/src/main/java/com/openstage/ticketbook/service/ContactService.java
@@ -1,0 +1,46 @@
+package com.openstage.ticketbook.service;
+
+import com.openstage.ticketbook.dto.ContactDTO;
+import com.openstage.ticketbook.model.Contact;
+import com.openstage.ticketbook.model.User;
+import com.openstage.ticketbook.repo.ContactRepo;
+import com.openstage.ticketbook.repo.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContactService {
+    private final ContactRepo contactRepo;
+    private final UserRepository userRepository;
+    private final HttpServletRequest request;
+
+    public Contact createContact(ContactDTO contactDTO) {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("USER_ID") == null) {
+            throw new RuntimeException("Error: User not logged in.");
+        }
+        Long userId = (Long) session.getAttribute("USER_ID");
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Error: User not found."));
+
+        Contact contact = Contact.builder()
+                .email(user.getEmail())
+                .name(user.getUsername())
+                .message(contactDTO.getMessage())
+                .build();
+        return contactRepo.save(contact);
+    }
+
+    public List<Contact> getAllContacts() {
+        return contactRepo.findAll();
+    }
+
+    public void deleteContact(Long id) {
+        contactRepo.deleteById(id);
+    }
+}


### PR DESCRIPTION
## 📬 Feature: Contact/Feedback System

### Summary
Added a new contact/feedback feature that allows users to submit inquiries and administrators to manage them.

### Changes
- Implemented contact management endpoints
- Added role-based access control for admin operations
- Created authentication requirements for contact submissions

### API Endpoints

#### `GET /api/contact`
- **Description**: Retrieve a list of all contacts
- **Authentication**: Required
- **Authorization**: ADMIN role required
- **Response**: List of all contact submissions

#### `POST /api/contact`
- **Description**: Create a new contact/feedback submission
- **Authentication**: Required
- **Authorization**: Any authenticated user
- **Request Body**: Contact details (name, email, message, etc.)
- **Response**: Created contact record

#### `DELETE /api/contact/{id}`
- **Description**: Delete a contact by ID
- **Authentication**: Required
- **Authorization**: ADMIN role required
- **Parameters**: `id` - Contact ID to delete
- **Response**: Deletion confirmation

### Security
- All endpoints require authentication
- Admin-only operations (GET all contacts, DELETE) are protected by role-based access control
- Authenticated users can submit their own feedback/contact requests

### Testing
- [ ] Test contact submission as authenticated user
- [ ] Test contact listing as admin
- [ ] Test contact deletion as admin
- [ ] Verify non-admin users cannot access admin endpoints
- [ ] Verify unauthenticated requests are rejected